### PR TITLE
[doc] add addon installation process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,7 @@ Installation
 
 - pip install guillotina_dbusers
 - add `guillotina_dbusers` to list of applications in your guillotina configuration
-- install into your container using the `@addons` endpoint
-
+- install into your container using the `@addons` endpoint using `dbusers` as id.
 
 Available content types:
 - User


### PR DESCRIPTION
It's not obvious that `guillotina_dbusers` addon name is `dbusers` we need to dig into the source in order to retrieve it, IMHO it should be mention in the readme because it's required to install this addon into a container.